### PR TITLE
adding `directive.$inject` -- explicit annotation

### DIFF
--- a/angular-colorpicker-dr.js
+++ b/angular-colorpicker-dr.js
@@ -254,5 +254,6 @@
 	        }
         };
     };
+    directive.$inject = ["$compile","$document", "$window"];
     angular.module('colorpicker-dr', []).directive('colorPicker', directive);
 }());


### PR DESCRIPTION
hello,
This package running with `strict-di` mode is enabled, a error such as below is occured.

```
Error: [$injector:strictdi] directive is not using explicit annotation and cannot be invoked in strict mode
```

So, I adding `$injector`,  explicitly.

about: strict-di
- https://docs.angularjs.org/error/$injector/strictdi
