### PR TITLE
work around bug when SVG element is in DOM

### DIFF
--- a/angular-colorpicker-dr.js
+++ b/angular-colorpicker-dr.js
@@ -246,7 +246,7 @@
 					var i,
 						docChildren = $document.find('body').children();
 					for (i = 0; i < docChildren.length; i++) {
-						if (docChildren[i].className.indexOf('color-picker-wrapper body') !== -1) {
+						if (docChildren[i].getAttribute("class") && docChildren[i].getAttribute("class").indexOf('color-picker-wrapper body') !== -1) {
 							angular.element(docChildren[i]).addClass('hide');
 						}
 					}


### PR DESCRIPTION
As you are looping through all Children .className.indexOf will break when an SVG element is present in the DOM (as svg.className is an object SVGAnimatedString {animVal: "", baseVal: ""})
